### PR TITLE
Fix various typos reported by Debian's Lintian

### DIFF
--- a/Common/c3270/c3270.c
+++ b/Common/c3270/c3270.c
@@ -834,7 +834,7 @@ synchronous_signal(iosrc_t fd, ioid_t id)
     }
 
     if (!escaped) {
-	vtrace("Ingoring synchronous signals\n");
+	vtrace("Ignoring synchronous signals\n");
 	return;
     }
 
@@ -856,7 +856,7 @@ synchronous_signal(iosrc_t fd, ioid_t id)
 	    vtrace("SIGINT while running an action\n");
 	    abort_script_by_cb(command_cb.shortname);
 	} else if (!aux_input) {
-	    vtrace("SIGINT at the normal prompt -- ignorning\n");
+	    vtrace("SIGINT at the normal prompt -- ignoring\n");
 	} else {
 	    vtrace("SIGINT with aux input -- aborting action\n");
 #if defined(HAVE_LIBREADLINE) /*[*/
@@ -937,7 +937,7 @@ windows_sigint(iosrc_t fd, ioid_t id)
 	vtrace("SIGINT while running an action\n");
 	abort_script_by_cb(command_cb.shortname);
     } else if (!aux_input) {
-	vtrace("SIGINT at the normal prompt -- ignorning\n");
+	vtrace("SIGINT at the normal prompt -- ignoring\n");
     } else {
 	vtrace("SIGINT with aux input -- handled when 0-length read arrives\n");
     }

--- a/Common/c3270/keymap.c
+++ b/Common/c3270/keymap.c
@@ -1023,7 +1023,7 @@ set_inactive(void)
 	    }
     }
 
-    /* Compute superceded entries. */
+    /* Compute superseded entries. */
     for (k = master_keymap; k != NULL; k = k->next) {
 	if (k->hints[0] & KM_INACTIVE) {
 	    continue;
@@ -1124,7 +1124,7 @@ keymap_dump(void)
 
     for (k = master_keymap; k != NULL; k = k->next) {
 	if (k->successor != NULL) {
-	    vb_appendf(&r, "[%s:%d%s] -- superceded by %s:%d --\n",
+	    vb_appendf(&r, "[%s:%d%s] -- superseded by %s:%d --\n",
 		    k->file, k->line,
 		    k->temp? " temp": "",
 		    k->successor->file, k->successor->line);

--- a/Common/fb-common
+++ b/Common/fb-common
@@ -41,4 +41,4 @@ x3270.message.ftCutConversionError:	Data conversion error
 x3270.message.ftCutOversize:		Illegal frame length
 x3270.message.ftDisconnected:		Host disconnected, transfer cancelled
 x3270.message.ftNot3270:		Not in 3270 mode, transfer cancelled
-x3270.message.ftDftUnknownOpen:		Uknown DFT Open type from host
+x3270.message.ftDftUnknownOpen:		Unknown DFT Open type from host

--- a/Common/glue.c
+++ b/Common/glue.c
@@ -529,7 +529,7 @@ static opt_t base_opts[] = {
     "<name>", "Device name (workstation ID) for RFC 4777" },
 #if defined(LOCAL_PROCESS) /*[*/
 { OptLocalProcess,OPT_SKIP2,false, NULL,         NULL,
-    "<command> [<arg>...]", "Run <command> instead of making TELNET conection"
+    "<command> [<arg>...]", "Run <command> instead of making TELNET connection"
 },
 #endif /*]*/
 { OptHostsFile,OPT_STRING,  false, ResHostsFile, aoffset(hostsfile),

--- a/Common/ibm_hosts.man.m4
+++ b/Common/ibm_hosts.man.m4
@@ -63,7 +63,7 @@ XX_FB(oddlu@bluehost).
 Finally, it can include a non-default XX_FI(port) number, appended to the
 XX_FI(hostname) with a colon ``:'' character, e.g.,
 XX_FB(bluehost:97).
-(For compatability with earlier versions of XX_FI(x3270),
+(For compatibility with earlier versions of XX_FI(x3270),
 the XX_FI(port) can also be separated by a slash ``/'' character.)
 XX_LP
 The optional XX_FI(actions)

--- a/Common/libexpat/expat.h
+++ b/Common/libexpat/expat.h
@@ -342,7 +342,7 @@ XML_SetEntityDeclHandler(XML_Parser parser,
                          XML_EntityDeclHandler handler);
 
 /* OBSOLETE -- OBSOLETE -- OBSOLETE
-   This handler has been superceded by the EntityDeclHandler above.
+   This handler has been superseded by the EntityDeclHandler above.
    It is provided here for backward compatibility.
 
    This is called for a declaration of an unparsed (NDATA) entity.

--- a/c3270/ibm_hosts.man
+++ b/c3270/ibm_hosts.man
@@ -40,7 +40,7 @@ It can also include an LU name, separated by an `@' character, e.g.,
 Finally, it can include a non-default \fIport\fP number, appended to the
 \fIhostname\fP with a colon `:' character, e.g.,
 \fBbluehost:97\fP.
-(For compatability with earlier versions of \fIx3270\fP,
+(For compatibility with earlier versions of \fIx3270\fP,
 the \fIport\fP can also be separated by a slash `/' character.)
 .LP
 The optional \fIactions\fP

--- a/c3270/screen.c
+++ b/c3270/screen.c
@@ -376,13 +376,13 @@ screen_init(void)
 	parse_screen_spec(appres.c3270.altscreen, &altscreen_spec);
 	if (altscreen_spec.rows < 27 || altscreen_spec.cols < 132) {
 	    fprintf(stderr, "Rows and/or cols too small on "
-		"alternate screen (mininum 27x132)\n");
+		"alternate screen (minimum 27x132)\n");
 	    exit(1);
 	}
 	parse_screen_spec(appres.c3270.defscreen, &defscreen_spec);
 	if (defscreen_spec.rows < 24 || defscreen_spec.cols < 80) {
 	    fprintf(stderr, "Rows and/or cols too small on "
-		"default screen (mininum 24x80)\n");
+		"default screen (minimum 24x80)\n");
 	    exit(1);
 	}
     }

--- a/wc3270/keymap.c
+++ b/wc3270/keymap.c
@@ -337,7 +337,7 @@ locate_keymap(const char *name, char **fullname, char **r)
 }
 
 /*
- * Compare a pair of keymaps for compatablity (could k2 match k1).
+ * Compare a pair of keymaps for compatiblity (could k2 match k1).
  * N.B.: This functon may need to be further parameterized for equality versus
  * (ambiguous) matching.
  */
@@ -1136,7 +1136,7 @@ set_inactive(void)
 	}
     }
 
-    /* Compute superceded entries. */
+    /* Compute superseded entries. */
     for (k = master_keymap; k != NULL; k = k->next) {
 	if (k->hints[0] & KM_INACTIVE) {
 	    continue;
@@ -1145,7 +1145,7 @@ set_inactive(void)
 	    if (j->hints[0] & KM_INACTIVE) {
 		continue;
 	    }
-	    /* It may supercede other entries. */
+	    /* It may supersede other entries. */
 	    if (j->ncodes == k->ncodes && !codecmp(j, k, k->ncodes)) {
 		j->hints[0] |= KM_INACTIVE;
 		j->successor = k;

--- a/x3270/ibm_hosts.man
+++ b/x3270/ibm_hosts.man
@@ -40,7 +40,7 @@ It can also include an LU name, separated by an `@' character, e.g.,
 Finally, it can include a non-default \fIport\fP number, appended to the
 \fIhostname\fP with a colon `:' character, e.g.,
 \fBbluehost:97\fP.
-(For compatability with earlier versions of \fIx3270\fP,
+(For compatibility with earlier versions of \fIx3270\fP,
 the \fIport\fP can also be separated by a slash `/' character.)
 .LP
 The optional \fIactions\fP


### PR DESCRIPTION
It picks up typos in strings compiled into the executable. I also fixed the comments I found that had the same typos.