### PR TITLE
Invoke net_connected_complete after proxy connect

### DIFF
--- a/Common/telnet.c
+++ b/Common/telnet.c
@@ -1314,7 +1314,7 @@ net_input(iosrc_t fd _is_unused, ioid_t id _is_unused)
 	    host_disconnect(true);
 	    return;
 	}
-	change_cstate(TELNET_PENDING, "net_input");
+	net_connected_complete();
     }
 
     if (cstate == TLS_PENDING) {


### PR DESCRIPTION
connect-disconnect-connect does not work right now over a proxy
connection. The problem appears to be stale data in myopts.  For
normal connections this data structure is zeroed out by
net_connected_complete. However, this does not appear to happen for
connections via proxy.  These connections need more steps and will be
completed via net_input->proxy_continue invocations.

With this patch net_connected_complete is called on that path as
well.  This fixes the problem for me.