### PR TITLE
added save recall in screen options

### DIFF
--- a/x3270/keymap.c
+++ b/x3270/keymap.c
@@ -161,6 +161,22 @@ keymap_init(const char *km, bool interactive)
     }
 }
 
+
+
+void
+save_screen()
+{
+	save_image();
+    printf("exporting \n");
+}
+
+void
+recall_screen()
+{
+	recall_image();
+    printf("importing \n");
+}
+
 /*
  * 3270/NVT mode change.
  */

--- a/x3270/keymap.h
+++ b/x3270/keymap.h
@@ -52,6 +52,9 @@ extern struct trans_list *temp_keymaps;
 
 void do_keymap_display(Widget w, XtPointer userdata, XtPointer calldata);
 void keymap_init(const char *km, bool interactive);
+void save_screen();
+void recall_screen();
+
 XtTranslations lookup_tt(const char *name, char *table);
 void PA_End_xaction(Widget w, XEvent *event, String *params,
 	Cardinal *num_params);

--- a/x3270/menubar.c
+++ b/x3270/menubar.c
@@ -1876,6 +1876,23 @@ do_snap(Widget w _is_unused, XtPointer userdata _is_unused,
     screen_snap_size();
 }
 
+/* Callback from the "Snap" menu option */
+static void
+do_save_screen(Widget w _is_unused, XtPointer userdata _is_unused,
+	XtPointer calldata _is_unused)
+{
+    save_screen();
+}
+
+/* Callback from the "Snap" menu option */
+static void
+do_recall_screen(Widget w _is_unused, XtPointer userdata _is_unused,
+	XtPointer calldata _is_unused)
+{
+    recall_screen();
+}
+
+
 /* Called to change telnet modes */
 static void
 linemode_callback(Widget w _is_unused, XtPointer client_data _is_unused,
@@ -2174,7 +2191,6 @@ options_menu_init(bool regen, Position x, Position y)
 	toggle_init(t, VISIBLE_CONTROL, "visibleControlOption", NULL, &spaced);
 	toggle_init(t, TYPEAHEAD, "typeaheadOption", NULL, &spaced);
 	toggle_init(t, ALWAYS_INSERT, "alwaysInsertOption", NULL, &spaced);
-	toggle_init(t, SELECT_URL, "selectUrlOption", NULL, &spaced);
 	spaced = false;
 	toggle_init(t, ALT_CURSOR, "underlineCursorOption",
 		"blockCursorOption", &spaced);
@@ -2291,6 +2307,31 @@ options_menu_init(bool regen, Position x, Position y)
 		NULL);
 	any |= (snap_button != NULL);
     }
+    
+
+    /* Create the "save" option. */
+    if (!item_suppressed(options_menu, "saveScreen")) {
+	spaced = false;
+	snap_button = add_menu_itemv("Save Screen", options_menu,
+		do_save_screen, NULL,
+		&spaced,
+		XtNsensitive, snap_enabled,
+		NULL);
+	any |= (snap_button != NULL);
+    }
+
+    /* Create the "recall" option. */
+    if (!item_suppressed(options_menu, "recallScreen")) {
+	spaced = false;
+	snap_button = add_menu_itemv("Recall Screen", options_menu,
+		do_recall_screen, NULL,
+		&spaced,
+		XtNsensitive, snap_enabled,
+		NULL);
+	any |= (snap_button != NULL);
+    }
+
+
 
     /* Create the "models" pullright */
     if (!item_suppressed(options_menu, "modelsOption")) {

--- a/x3270/xscreen.h
+++ b/x3270/xscreen.h
@@ -161,6 +161,8 @@ void set_aicon_label(char *l);
 void set_translations(Widget w, XtTranslations *t00, XtTranslations *t0);
 void shift_event(int event_state);
 void screen_register(void);
+void save_image(void);
+void recall_image(void);
 XChar2b screen_vcrosshair(void);
 Dimension rescale(Dimension d);
 


### PR DESCRIPTION
Was thinking something like this might be useful, an ability to recall a screen and buffer so you can send the same data again with some/none variation. Added the save and recall commands in the x3270 options menu. Everything seems to work when i was testing it :sweat_smile: 

love this program, keep up the good work
![recall_save_screen](https://user-images.githubusercontent.com/16941112/109361138-59a40300-7880-11eb-8f7a-96a44e5480bb.png)

thanks 
jake