### PR TITLE
Increase timeout for file transfer start to 30 seconds

### DIFF
--- a/Common/fb-common
+++ b/Common/fb-common
@@ -31,7 +31,7 @@
 x3270.message.ftComplete:		Transfer complete, %i bytes transferred\n\
 %sbytes/sec in %s mode
 x3270.message.ftUnable:			Cannot begin transfer
-x3270.message.ftStartTimeout:		Transfer did not start within 10s
+x3270.message.ftStartTimeout:		Transfer did not start within 30s
 x3270.message.ftUserCancel:		Transfer cancelled by user
 x3270.message.ftHostCancel:		Transfer cancelled by host
 x3270.message.ftCutUnknownFrame:	Unknown frame type from host

--- a/Common/ft.c
+++ b/Common/ft.c
@@ -1041,7 +1041,7 @@ ft_start_backend(ft_conf_t *p, enum iaction cause)
     ft_gui_awaiting();
 
     /* Set a timeout for failed command start. */
-    ft_start_id = AddTimeOut(10 * 1000, ft_didnt_start);
+    ft_start_id = AddTimeOut(30 * 1000, ft_didnt_start);
 
     /* Success. */
     return true;


### PR DESCRIPTION
To avoid early timeouts.

Signed-off-by: Alexander Egorenkov <egorenar@linux.ibm.com>