### PR TITLE
Make sure that resolution-specific icon directories exist

### DIFF
--- a/x3270/Makefile.obj.in
+++ b/x3270/Makefile.obj.in
@@ -137,6 +137,7 @@ install::
 	if [ -d $(DESTDIR)$(ICONDIR) ]; \
 	then	for icon in $(ICONS); \
 		do	res=`echo $$icon | sed -e s/x3270-// -e s/.png//`; \
+			mkdir -p $(DESTDIR)$(ICONDIR)/$$res/apps/; \
 			$(INSTALL_DATA) $$icon $(DESTDIR)$(ICONDIR)/$$res/apps/x3270.png; \
 		done; \
 	fi


### PR DESCRIPTION
The build system only checks if $(ICONDIR) exists and then attempts to
copy files into a subdirectory that is not guaranteed to exist -
especially not during a Debian package build where it installs into
an essentially empty slate.