### PR TITLE
Add bg attribute during repeat-to-address

### DIFF
--- a/Common/ctlr.c
+++ b/Common/ctlr.c
@@ -1577,6 +1577,7 @@ ctlr_write(unsigned char buf[], size_t buflen, bool erase)
 		    }
 		}
 		ctlr_add_fg(buffer_addr, default_fg);
+		ctlr_add_bg(buffer_addr, default_bg);
 		ctlr_add_gr(buffer_addr, default_gr);
 		ctlr_add_ic(buffer_addr, default_ic);
 		INC_BA(buffer_addr);


### PR DESCRIPTION
The RA order currently doesn't set the background color. The IBM3270 Datastream Programmer's reference mandates "Attribute values defined by a previous SA order(s) are applied to each repeated character."