### PR TITLE
Fix a buffer overflow in the tn3270 common code

### DIFF
--- a/Common/telnet.c
+++ b/Common/telnet.c
@@ -2114,7 +2114,7 @@ tn3270e_request(void)
 
     /* Always use 3278, per the RFC. */
     xtn = create_3270_termtype(true);
-    tt_len = strlen(termtype);
+    tt_len = strlen(xtn);
     if (try_lu != NULL && *try_lu) {
 	tt_len += strlen(try_lu) + 1;
     }


### PR DESCRIPTION
#### Description

This pull-request fixes a buffer overflow and the affected logic caused by an incorrectly calculated size for the `tt_out` buffer.

One of the manifestations of the bug is a hanging E3270 session when the "-oversize" parameter is used; this is due to `tn_len` being off by 1 and as a result, `net_hexnvt_out_framed` using a truncated value from `tt_out`.

You can see that when tracing is on.

Without the fix, there is a sequence "ffff" at the end of the request:
```
> 0x0   fffa28020749424d2d333237382d342d45ffff
20250206.114810.709 SENT SB TN3270E DEVICE-TYPE REQUEST IBM-3278-4-E SE
20250206.114810.716 sched: Waiting for 5 events
```
whereas it should be "fff0":
```
> 0x0   fffa28020749424d2d333237382d342d45fff0
20250206.133354.262 SENT SB TN3270E DEVICE-TYPE REQUEST IBM-3278-4-E SE
20250206.133354.269 sched: Waiting for 5 events
```

This happens because the code in `net_hexnvt_out_framed` never copies the last `f0` in the logic after the comment ` /* Expand it. */`.